### PR TITLE
Deploy as dmtn-097.lsst.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,246 @@
-DMTN-*.aux
-DMTN-*.bbl
-DMTN-*.blg
-DMTN-*.glg
-DMTN-*.glo
-DMTN-*.gls
-DMTN-*.ist
-DMTN-*.log
-DMTN-*.out
-DMTN-*.pdf
-DMTN-*.rec
-DMTN-*.toc
+# Build by CI
+DMTN-097.pdf
 meta.tex
-*.swp
+
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Comment the next line if you want to keep your tikz graphics files
+*.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+*.ist
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# easy-todo
+*.lod
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices
+*.xyc
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# Kile
+*.backup
+
+# KBibTeX
+*~[0-9]*
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# generated if using elsarticle.cls
+*.spl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: true
+dist: trusty
+services:
+  - docker
+language: python
+python:
+  - '3.5'
+before_install:
+  - "pip install 'lander>=0.1.0,<0.2'"
+script:
+  # Compile PDF using containerized lsst-texmf
+  - "docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texmf:latest sh -c 'make'"
+  # Deploy website. See https://github.com/lsst-sqre/lander for CLI options
+  - lander --pdf DMTN-097.pdf --upload --env=travis --ltd-product dmtn-097 --title "LSST Auxiliary Telescope observation strategy" --handle DMTN-097
+env:
+  global:
+    # Add LSST the Docs credentials
+    - secure: "kV4rQX8ICAwVq//YbSu1cnHBNsc0rk5gkuxU9mufBoskuFcZNXom1g6zuSMy0B6Uz7CZrH53zSAe0fGspjTtjFQD7flHYVBSNTxnwc+8nPAUIXV8OT6cq0WxYm4QDy3k+pLG9npb5kPbU5m/DAF0OlLHoPk5gKFxexGs9C/gi0EH/euVC0dv/HkSM9VhLHDkXiQSq1/VabddaqFd1/kdV/jGjmlIbzA5oO/Z5VxdgBR247tf1/PF4VUrbM0EfvZX4bEwZCNSMt3Ty9ZMrDrScJaPidq6hSK1+sCjF8tsqblVCAKCCOsKOfHZarTUITiFY9cS0dlsO2ykyxtC9RLEj8lPmSRQcNTXxDW+fs7AJkL1/akpmQBqMpTHztR8N4b/tlsZkvJTiBgAMQUEcifKjtXUjThY2+6DTwvKP46oilIjvNiwPEeeF3JKyd/NJ406mRTHFDlE6zXBaNap02X2s+9paccC8I+FpRjQ6/0JmZfYEy0X+z9nr7u/wIOVR+PVIJuF0PY2ziHARvUbp4mHj7AFzFPM/0NRHnXVsxHaQdUoaHCz/XteTS8kpsqdH2Sb3S6/C1cF+kOWxi/rVwca5woOFfgLjO0vlRgAKB6Xz9oa26nBkwiSwP6VOvWmS/+OKp9QCqQggzunMqI+z/ofdZDQ8oHGUbLWBKuudPfshAY="
+    - secure: "F4pGH3CBm6Il1L2eXxUuJKoIyQ7rx4d9ftCyZ6/q2VpBeINYOCSnpsQZk0p1NpFzvmn64acLn7IMOSj0Z0mWzD7P9MbiPKNndy+M0fV1/Unn8fqauo07DHL+jvZ5JbCGGSDkbbN8wY2OXPrqh6xxi4aWIuFUhHoAU69RPc+G/t8/9HL2RKHgmr7V2Wa4MP9mdlT4Y/PSqVBAurDn9vXfZvrz3i/pYXKo7wRq6U8oSZ8UdB92nNDirQOEgH7j97qID/qjjdJm8XNGUwA7lGtmgNnNQr8lNCN9i1AL7NDriBKTCKhZb2vMWIzKVEx35daZQl85FSfGDwcwr9f8uwZysf4H5OYKo6sMet4atKFcFHBNn0XUTUICsHvM5APS6RKQa5igBK2FVoACT1NcIymyBzx1MDq+c+P9Hsbr4/BRxQMroqEF41PBaCpJh+HT5ESqtiIYtPY/aR1w+3CzIrWCBCibURhNkfawZT9kWf5k06yTzWSVOjY1NYxFGK9QgLYa+LWBrXFiCf97lQud5v8NxvQuXHi/v39Oe1ZW9iFhaNj+mIPvOdMMGOqAwIQy8OXqhNKDpB/gQkaxr63o5ga+0rhkA65jksFLYTzINFMTyGnTBRK2Gj9pYPDgXKC+B3ty3K4n+PV8VxNq4wgt/AQvX06QeSTUpHaV9ZTMc4E6bWg="

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,16 @@
+.. image:: https://img.shields.io/badge/dmtn--097-lsst.io-brightgreen.svg
+   :target: https://dmtn-097.lsst.io
+.. image:: https://travis-ci.org/lsst-dm/dmtn-097.svg
+   :target: https://travis-ci.org/lsst-dm/dmtn-097
+
+#############################################
+LSST Auxiliary Telescope observation strategy
+#############################################
+
+DMTN-097
+========
+
+**Links**
+
+- Live drafts: https://dmtn-097.lsst.io
+- GitHub: https://github.com/dmtn-097/dmtn-097


### PR DESCRIPTION
- Remove build PDF product from repo and gitignore it.
- Add a Travis CI config with credentials to upload to LSST the Docs. This Travis CI config uses a slightly different invocation of `lander` to work with the document not being lsstdoc format.
- Tweak the Makefile

I can't reproduce the document build inside LSST's texmf Docker container. Take a look a the build lots in https://travis-ci.org/lsst-dm/dmtn-097/builds/441955467 and you might be able to fix it.

Otherwise, this deployment is ready for you to merge.

This is a preview of the build (albeit with an incomplete PDF render): https://dmtn-097.lsst.io/v/u-jonathansick-config/index.html